### PR TITLE
add arrow body style catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = {
     'react/jsx-uses-react': 'error',
     'react-native/no-unused-styles': 2,
     'react-native/no-inline-styles': 2,
-    'react-native/no-color-literals': 2
+    'react-native/no-color-literals': 2,
+    'arrow-body-style': ['error', 'as-needed']
   }
 }


### PR DESCRIPTION
require { } curly brackets in arrow style functions only as needed: 

error when:
```
let foo = () => {
    return 0;
};
let foo = () => {
    return {
       bar: {
            foo: 1,
            bar: 2,
        }
    };
};
```

correct when: 
```
let foo = () => 0;
let foo = (retv, name) => {
    retv[name] = true;
    return retv;
};
let foo = () => ({
    bar: {
        foo: 1,
        bar: 2,
    }
});
let foo = () => { bar(); };
let foo = () => {};
let foo = () => { /* do nothing */ };
let foo = () => {
    // do nothing.
};
let foo = () => ({ bar: 0 });
```