### PR TITLE
Upgrade dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,96 +4,98 @@ module.exports = {
     node: true,
     jest: true
   },
-  extends: [
-    'eslint:recommended',
-    'prettier'
-  ],
-  plugins: [
-    'react',
-    'react-native',
-    'prettier',
-    'unicorn'
-  ],
-  parser: 'babel-eslint',
+  extends: ["eslint:recommended", "prettier"],
+  plugins: ["react", "react-native", "prettier", "unicorn"],
+  parser: "babel-eslint",
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'module',
+    sourceType: "module",
     ecmaFeatures: {
       jsx: true,
       experimentalObjectRestSpread: true
     }
   },
-  rules: {
-    'prettier/prettier': ['error',
-      {
-        "bracketSpacing": true,
-        "jsxBracketSameLine": true,
-        "printWidth": 80,
-        "singleQuote": true,
-        "semi": false,
-        "useTabs": false,
-        "trailingComma": "es5"
-      }
-    ],
-    'react/no-deprecated': 'error',
-    'react/no-children-prop': 'error',
-    'react/no-direct-mutation-state': 'error',
-    'react/default-props-match-prop-types': 'error',
-    'react/jsx-no-comment-textnodes': 'error',
-    'react/jsx-handler-names': 'error',
-    'react/jsx-max-props-per-line': [
-      'error',
-      {
-        'maximum': 1,
-        'when': 'multiline'
-      }
-    ],
-    'react/jsx-sort-props': [
-      'error',
-      {
-        'callbacksLast': true,
-        'shorthandFirst': true,
-        'noSortAlphabetically': true,
-        'reservedFirst': true
-      }
-    ],
-    'react/jsx-no-duplicate-props': [
-      'error',
-      {
-        'ignoreCase': true
-      }
-    ],
-    'react/jsx-uses-vars': 'error',
-    'react/jsx-uses-react': 'error',
-    'react-native/no-unused-styles': 2,
-    'react-native/no-inline-styles': 2,
-    'react-native/no-color-literals': 2,
-    'arrow-body-style': ['error', 'as-needed'],
-    'unicorn/catch-error-name': 'error',
-    'unicorn/no-abusive-eslint-disable': 'error',
-    'unicorn/throw-new-error': 'error',
-    'unicorn/escape-case': 'error',
-    'unicorn/no-array-instanceof': 'error',
-    'unicorn/no-new-buffer': 'error',
-    'unicorn/no-hex-escape': 'error',
-    'unicorn/prefer-starts-ends-with': 'error',
-    'unicorn/prefer-type-error': 'error',
-    'unicorn/import-index': 'error',
-    'unicorn/new-for-builtins': 'error',
-    'unicorn/filename-case': ['error', {'case': 'kebabCase'}]
+  settings: {
+    react: {
+      version: "16.4.0"
+    }
   },
-  'overrides': [
+  rules: {
+    "prettier/prettier": [
+      "error",
+      {
+        bracketSpacing: true,
+        jsxBracketSameLine: true,
+        printWidth: 80,
+        singleQuote: true,
+        semi: false,
+        useTabs: false,
+        trailingComma: "es5"
+      }
+    ],
+    "react/no-deprecated": "error",
+    "react/no-children-prop": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/default-props-match-prop-types": "error",
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-handler-names": "error",
+    "react/jsx-max-props-per-line": [
+      "error",
+      {
+        maximum: 1,
+        when: "multiline"
+      }
+    ],
+    "react/jsx-sort-props": [
+      "error",
+      {
+        callbacksLast: true,
+        shorthandFirst: true,
+        noSortAlphabetically: true,
+        reservedFirst: true
+      }
+    ],
+    "react/jsx-no-duplicate-props": [
+      "error",
+      {
+        ignoreCase: true
+      }
+    ],
+    "react/jsx-uses-vars": "error",
+    "react/jsx-uses-react": "error",
+    "react-native/no-unused-styles": 2,
+    "react-native/no-inline-styles": 2,
+    "react-native/no-color-literals": 2,
+    "arrow-body-style": ["error", "as-needed"],
+    "unicorn/catch-error-name": "error",
+    "unicorn/no-abusive-eslint-disable": "error",
+    "unicorn/throw-new-error": "error",
+    "unicorn/escape-case": "error",
+    "unicorn/no-array-instanceof": "error",
+    "unicorn/no-new-buffer": "error",
+    "unicorn/no-hex-escape": "error",
+    "unicorn/prefer-starts-ends-with": "error",
+    "unicorn/prefer-type-error": "error",
+    "unicorn/import-index": "error",
+    "unicorn/new-for-builtins": "error",
+    "unicorn/filename-case": ["error", { case: "kebabCase" }],
+    "unicorn/catch-error-name": [
+      "error",
+      { caughtErrorsIgnorePattern: "^err*$" }
+    ]
+  },
+  overrides: [
     {
-      'files': ['src/components/**/*.js', 'src/containers/**/*.js'],
-      'rules': {
-        'unicorn/filename-case': ['error', {'case': 'pascalCase'}]
+      files: ["src/components/**/*.js", "src/containers/**/*.js"],
+      rules: {
+        "unicorn/filename-case": ["error", { case: "pascalCase" }]
       }
     },
     {
-      'files': ['**/*.test.js'],
-      'rules': {
-        'unicorn/filename-case': 0
+      files: ["**/*.test.js"],
+      rules: {
+        "unicorn/filename-case": 0
       }
     }
   ]
-}
+};

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   },
   "homepage": "https://github.com/localz/eslint-config-react-native-localz#readme",
   "dependencies": {
-    "babel-eslint": "8.2.6",
-    "eslint-config-prettier": "3.0.1",
-    "eslint-plugin-prettier": "2.6.2",
-    "eslint-plugin-react": "7.5.1",
-    "eslint-plugin-react-native": "3.1.0",
-    "eslint-plugin-unicorn": "3.0.1"
+    "babel-eslint": "10.0.1",
+    "eslint-config-prettier": "3.1.0",
+    "eslint-plugin-prettier": "3.0.0",
+    "eslint-plugin-react": "7.11.1",
+    "eslint-plugin-react-native": "3.3.0",
+    "eslint-plugin-unicorn": "6.0.1"
   },
   "peerDependencies": {
     "eslint": ">=4.11.0",
-    "prettier": ">=1.9.2"
+    "prettier": ">=1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-unicorn": "6.0.1"
   },
   "peerDependencies": {
-    "eslint": ">=4.11.0",
+    "eslint": ">=5.0.0",
     "prettier": ">=1.13.0"
   }
 }


### PR DESCRIPTION
Upgrading the following dependencies to the following versions:

```
    "babel-eslint": "10.0.1",
    "eslint-config-prettier": "3.1.0",
    "eslint-plugin-prettier": "3.0.0",
    "eslint-plugin-react": "7.11.1",
    "eslint-plugin-react-native": "3.3.0",
    "eslint-plugin-unicorn": "6.0.1"
```

Also setting peer dependencies of eslint to v5 or above, and prettier to v1.13.0 or above.

Note: there might be a risk of some breaking changes but for the most part, these changes should be minimal.