### PR TITLE
add jsx-no-undef rule from react eslint plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
     "react/no-direct-mutation-state": "error",
     "react/default-props-match-prop-types": "error",
     "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-undef": "error",
     "react/jsx-handler-names": "error",
     "react/jsx-max-props-per-line": [
       "error",


### PR DESCRIPTION
Adding `react/jsx-no-undef` rule to check for usage of undefined identifiers as JSX tag names.
the base eslint rule `no-undef` doesn't appear to check JSX tag names, e.g. `<HelperText />` would pass, even if the there was no `HelperText` import / variable in file scrope

will publish this as a major release due to the potential for linting errors to be raised after dependants upgrade